### PR TITLE
fix: RestClient URI 템플릿 변수 사용으로 Micrometer URI 태그 초과 해결

### DIFF
--- a/src/main/java/kr/solta/adapter/solvedac/SolvedAcRestClient.java
+++ b/src/main/java/kr/solta/adapter/solvedac/SolvedAcRestClient.java
@@ -62,7 +62,7 @@ public class SolvedAcRestClient implements SolvedAcClient {
                 .collect(Collectors.joining(","));
 
         List<SolvedAcProblemResponse> result = restClient.get()
-                .uri(LOOKUP_URL + "?problemIds=" + ids)
+                .uri(LOOKUP_URL + "?problemIds={ids}", ids)
                 .retrieve()
                 .body(new ParameterizedTypeReference<>() {});
 


### PR DESCRIPTION
## 배경
운영 서버 로그 점검 중 ProblemSync 문제 동기화 과정에서 아래 WARN 로그가 발견됨:

```json
{
  "level": "WARN",
  "@timestamp": "2026-02-15 06:00:58.425+0900",
  "logger_name": "org.springframework.boot.actuate.autoconfigure.metrics.OnlyOnceLoggingDenyMeterFilter",
  "thread_name": "scheduling-1",
  "message": "Reached the maximum number of URI tags for 'http.client.requests'. Are you using 'uriVariables'?"
}
```

동기화 시작(`06:00:00`) 후 약 1분 만에 발생하며, 이후 기존 문제 261건 업데이트 + 신규 문제 57건 등록까지는 정상 완료됨.

## 원인 분석
`SolvedAcRestClient.lookupProblems()`에서 solved.ac API를 호출할 때 URI를 문자열 연결로 생성하고 있었음:

```java
// before
.uri(LOOKUP_URL + "?problemIds=" + ids)
```

ProblemSync는 100건씩 배치로 API를 호출하는데, 매 배치마다 `problemIds` 쿼리 파라미터 값이 달라짐:
- 1번째 호출: `/api/v3/problem/lookup?problemIds=1000,1001,...,1099`
- 2번째 호출: `/api/v3/problem/lookup?problemIds=1100,1101,...,1199`
- ...

Spring Boot Actuator의 Micrometer는 `http.client.requests` 메트릭을 URI별로 태깅하는데, 문자열 연결 방식은 각 요청의 전체 URI(쿼리 파라미터 포함)를 별도 태그로 인식함.
동기화 시 수십 회의 배치 호출이 발생하면서 URI 태그 수가 기본 한도(100개)를 초과하여 `OnlyOnceLoggingDenyMeterFilter`가 WARN을 출력하고, 이후 요청의 메트릭이 기록되지 않음.

## 해결
URI 템플릿 변수를 사용하도록 변경:

```java
// after
.uri(LOOKUP_URL + "?problemIds={ids}", ids)
```

이렇게 하면 Micrometer가 실제 값이 아닌 템플릿 패턴(`/api/v3/problem/lookup?problemIds={ids}`)으로 태그를 집계하므로, 모든 배치 호출이 하나의 URI 태그로 통합되어 한도 초과가 발생하지 않음.