### PR TITLE
feat: GitHub README 배지 기능 구현

### DIFF
--- a/src/main/java/kr/solta/adapter/webapi/BadgeController.java
+++ b/src/main/java/kr/solta/adapter/webapi/BadgeController.java
@@ -1,0 +1,37 @@
+package kr.solta.adapter.webapi;
+
+import kr.solta.application.provided.BadgeReader;
+import kr.solta.application.provided.response.BadgeStatsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/badges")
+@RequiredArgsConstructor
+public class BadgeController {
+
+    private final BadgeReader badgeReader;
+
+    @CrossOrigin(origins = "*")
+    @GetMapping("/{username}")
+    public ResponseEntity<String> getBadge(@PathVariable final String username) {
+        String svg = badgeReader.generateBadgeSvg(username);
+        return ResponseEntity.ok()
+                .contentType(MediaType.valueOf("image/svg+xml"))
+                .header("Cache-Control", "no-cache, no-store, must-revalidate")
+                .header("Pragma", "no-cache")
+                .body(svg);
+    }
+
+    @GetMapping("/{username}/stats")
+    public ResponseEntity<BadgeStatsResponse> getBadgeStats(@PathVariable final String username) {
+        BadgeStatsResponse stats = badgeReader.getBadgeStats(username);
+        return ResponseEntity.ok(stats);
+    }
+}

--- a/src/main/java/kr/solta/application/BadgeService.java
+++ b/src/main/java/kr/solta/application/BadgeService.java
@@ -1,0 +1,131 @@
+package kr.solta.application;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import kr.solta.application.BadgeSvgGenerator.TierBarData;
+import kr.solta.application.provided.BadgeReader;
+import kr.solta.application.provided.response.BadgeStatsResponse;
+import kr.solta.application.provided.response.BadgeStatsResponse.TierDataItem;
+import kr.solta.application.required.MemberRepository;
+import kr.solta.application.required.SolvedRepository;
+import kr.solta.application.required.dto.BadgeSummaryStats;
+import kr.solta.application.required.dto.TierGroupStat;
+import kr.solta.domain.Member;
+import kr.solta.domain.Tier;
+import kr.solta.domain.TierGroup;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BadgeService implements BadgeReader {
+
+    private static final List<TierGroup> BADGE_TIER_GROUPS = List.of(
+            TierGroup.BRONZE,
+            TierGroup.SILVER,
+            TierGroup.GOLD,
+            TierGroup.PLATINUM,
+            TierGroup.DIAMOND,
+            TierGroup.RUBY
+    );
+
+    private static final Map<TierGroup, String> TIER_LABELS = Map.of(
+            TierGroup.BRONZE, "B",
+            TierGroup.SILVER, "S",
+            TierGroup.GOLD, "G",
+            TierGroup.PLATINUM, "P",
+            TierGroup.DIAMOND, "D",
+            TierGroup.RUBY, "R"
+    );
+
+    private static final Map<TierGroup, String> TIER_COLORS = Map.of(
+            TierGroup.BRONZE, "hsl(30,70%,45%)",
+            TierGroup.SILVER, "hsl(210,15%,60%)",
+            TierGroup.GOLD, "hsl(45,100%,50%)",
+            TierGroup.PLATINUM, "hsl(175,60%,55%)",
+            TierGroup.DIAMOND, "hsl(200,100%,65%)",
+            TierGroup.RUBY, "hsl(350,85%,55%)"
+    );
+
+    private final MemberRepository memberRepository;
+    private final SolvedRepository solvedRepository;
+    private final BadgeSvgGenerator badgeSvgGenerator;
+
+    @Transactional(readOnly = true)
+    @Override
+    public String generateBadgeSvg(final String username) {
+        BadgeStatsResponse stats = getBadgeStats(username);
+
+        List<TierBarData> tierData = stats.tierData().stream()
+                .map(item -> new TierBarData(item.label(), item.avgMinutes(), item.color()))
+                .toList();
+
+        return badgeSvgGenerator.generate(
+                stats.username(),
+                stats.totalMinutes(),
+                stats.avgMinutes(),
+                stats.selfSolveRate(),
+                tierData
+        );
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public BadgeStatsResponse getBadgeStats(final String username) {
+        Member member = memberRepository.findByName(username)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다. username: " + username));
+
+        BadgeSummaryStats summary = solvedRepository.findBadgeSummaryStats(member.getId());
+        Integer selfSolveRateRaw = solvedRepository.findSelfSolveRate(member.getId());
+        int selfSolveRate = selfSolveRateRaw != null ? selfSolveRateRaw : 0;
+
+        List<Tier> allBadgeTiers = BADGE_TIER_GROUPS.stream()
+                .flatMap(tg -> tg.getTiers().stream())
+                .toList();
+        List<TierGroupStat> tierGroupStats = solvedRepository.findBadgeTierGroupStats(member.getId(), allBadgeTiers);
+
+        Map<TierGroup, Double> avgSecondsByGroup = mapToTierGroupAvg(tierGroupStats);
+
+        int totalMinutes = (int) Math.round(summary.totalSeconds() / 60.0);
+        int avgMinutes = (int) Math.round(summary.avgSeconds() / 60.0);
+
+        List<TierDataItem> tierData = buildTierDataItems(avgSecondsByGroup);
+
+        return new BadgeStatsResponse(username, totalMinutes, avgMinutes, selfSolveRate, tierData);
+    }
+
+    private Map<TierGroup, Double> mapToTierGroupAvg(List<TierGroupStat> stats) {
+        Map<Tier, Double> avgByTier = stats.stream()
+                .collect(Collectors.toMap(TierGroupStat::tier, TierGroupStat::avgSeconds));
+
+        return BADGE_TIER_GROUPS.stream()
+                .collect(Collectors.toMap(
+                        tg -> tg,
+                        tg -> {
+                            List<Double> avgs = tg.getTiers().stream()
+                                    .filter(avgByTier::containsKey)
+                                    .map(avgByTier::get)
+                                    .toList();
+                            if (avgs.isEmpty()) return 0.0;
+                            return avgs.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+                        }
+                ));
+    }
+
+    private List<TierDataItem> buildTierDataItems(Map<TierGroup, Double> avgSecondsByGroup) {
+        List<TierDataItem> result = new ArrayList<>();
+        for (TierGroup tg : BADGE_TIER_GROUPS) {
+            double avgSeconds = avgSecondsByGroup.getOrDefault(tg, 0.0);
+            int avgMinutes = (int) Math.round(avgSeconds / 60.0);
+            result.add(new TierDataItem(
+                    TIER_LABELS.get(tg),
+                    avgMinutes,
+                    TIER_COLORS.get(tg)
+            ));
+        }
+        return result;
+    }
+}

--- a/src/main/java/kr/solta/application/BadgeSvgGenerator.java
+++ b/src/main/java/kr/solta/application/BadgeSvgGenerator.java
@@ -1,0 +1,301 @@
+package kr.solta.application;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BadgeSvgGenerator {
+
+    // ── Layout constants ──────────────────────────────────────────────────────
+    private static final int W = 400;
+    private static final int H = 165;
+    private static final int PAD = 14;
+    private static final int HEADER_H = 38;
+    private static final int DIV_X = 188;
+    private static final int CHART_X = DIV_X + 16;
+    private static final int CHART_R = W - PAD;
+    private static final int CHART_W = CHART_R - CHART_X;
+    private static final int C_BOTTOM = H - 20;
+    private static final int C_TOP = HEADER_H + 36;
+    private static final int MAX_BAR_H = C_BOTTOM - C_TOP;
+    private static final int BAR_W = 14;
+    private static final int CHART_GAP = 13;
+
+    // ── Colours ───────────────────────────────────────────────────────────────
+    private static final String TEXT = "#E4E6EB";
+    private static final String TEXT_SUB = "#8B949E";
+    private static final String DIVIDER = "rgba(255,255,255,0.09)";
+    private static final String LOGO_A = "#FF9A76";
+    private static final String LOGO_B = "#FF7C5C";
+    private static final String BG_START = "#0D1117";
+    private static final String BG_MID = "#142035";
+    private static final String BG_END = "#1c3554";
+
+    // ── Logo bar sizes ────────────────────────────────────────────────────────
+    private static final int[] BAR_SIZES = {7, 11, 15};
+    private static final int BAR_W_LOGO = 5;
+    private static final int BAR_GAP = 3;
+    private static final int BAR_BOTTOM = HEADER_H - 10;
+
+    public record TierBarData(String label, int avgMinutes, String color) {}
+
+    public String generate(
+            String username,
+            int totalMinutes,
+            int avgMinutes,
+            int selfSolveRate,
+            List<TierBarData> tierData
+    ) {
+        String uid = "b" + Math.abs((username + totalMinutes + avgMinutes).hashCode());
+
+        String bgId = "bg-" + uid;
+        String glossId = "gloss-" + uid;
+        String shimId = "shim-" + uid;
+        String shimKf = "shimKf-" + uid;
+        String clipId = "clip-" + uid;
+        String logoGradId = "logo-" + uid;
+        String wordmarkGradId = "wm-" + uid;
+
+        int logoEndX = PAD + BAR_SIZES.length * BAR_W_LOGO + (BAR_SIZES.length - 1) * BAR_GAP;
+
+        // ── Total time string ─────────────────────────────────────────────────
+        int totalH = totalMinutes / 60;
+        int totalM = totalMinutes % 60;
+        String totalTimeStr;
+        if (totalH > 0) {
+            totalTimeStr = totalH + "시간 " + totalM + "분";
+        } else {
+            totalTimeStr = totalM + "분";
+        }
+
+        // ── Active tier bars ──────────────────────────────────────────────────
+        List<TierBarData> active = tierData.stream()
+                .filter(d -> d.avgMinutes() > 0)
+                .toList();
+
+        int rawMax = active.stream()
+                .mapToInt(TierBarData::avgMinutes)
+                .max()
+                .orElse(60);
+        int scalingMax = Math.min(Math.max(rawMax, 60), 300);
+
+        int groupW = active.size() * BAR_W + (active.size() + 1) * CHART_GAP;
+        double chartOffX = CHART_X + (double) (CHART_W - groupW) / 2;
+
+        // ── Build SVG ─────────────────────────────────────────────────────────
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                """);
+
+        sb.append(String.format(
+                "<svg width=\"%d\" height=\"%d\" viewBox=\"0 0 %d %d\" xmlns=\"http://www.w3.org/2000/svg\">\n",
+                W, H, W, H
+        ));
+
+        // Style / keyframes
+        sb.append(String.format("""
+                <style>
+                  @keyframes %s {
+                    0%%   { transform: translateX(-280px) skewX(-18deg); opacity: 0; }
+                    6%%   { transform: translateX(-120px) skewX(-18deg); opacity: 1; }
+                    28%%  { transform: translateX(%dpx) skewX(-18deg); opacity: 1; }
+                    36%%  { transform: translateX(%dpx) skewX(-18deg); opacity: 0; }
+                    100%% { transform: translateX(%dpx) skewX(-18deg); opacity: 0; }
+                  }
+                  .%s { animation: %s 5s linear infinite; }
+                </style>
+                """, shimKf, W - 40, W + 120, W + 120, shimId, shimKf));
+
+        // Defs
+        sb.append("<defs>\n");
+
+        // Background gradient
+        sb.append(String.format("""
+                <linearGradient id="%s" x1="0%%" y1="0%%" x2="100%%" y2="100%%">
+                  <stop offset="0%%" stop-color="%s"/>
+                  <stop offset="50%%" stop-color="%s"/>
+                  <stop offset="100%%" stop-color="%s"/>
+                </linearGradient>
+                """, bgId, BG_START, BG_MID, BG_END));
+
+        // Gloss gradient
+        sb.append(String.format("""
+                <linearGradient id="%s" x1="0%%" y1="0%%" x2="0%%" y2="100%%">
+                  <stop offset="0%%" stop-color="rgba(255,255,255,0.06)"/>
+                  <stop offset="60%%" stop-color="rgba(255,255,255,0.01)"/>
+                  <stop offset="100%%" stop-color="rgba(255,255,255,0)"/>
+                </linearGradient>
+                """, glossId));
+
+        // Shimmer gradient
+        sb.append(String.format("""
+                <linearGradient id="%s-grad" x1="0%%" y1="0%%" x2="100%%" y2="0%%">
+                  <stop offset="0%%" stop-color="rgba(255,255,255,0)"/>
+                  <stop offset="30%%" stop-color="rgba(255,255,255,0.015)"/>
+                  <stop offset="50%%" stop-color="rgba(255,255,255,0.025)"/>
+                  <stop offset="70%%" stop-color="rgba(255,255,255,0.015)"/>
+                  <stop offset="100%%" stop-color="rgba(255,255,255,0)"/>
+                </linearGradient>
+                """, shimId));
+
+        // Logo gradient
+        sb.append(String.format("""
+                <linearGradient id="%s" gradientUnits="userSpaceOnUse"
+                    x1="%d" y1="%d" x2="%d" y2="%d">
+                  <stop offset="0%%" stop-color="%s"/>
+                  <stop offset="100%%" stop-color="%s"/>
+                </linearGradient>
+                """, logoGradId, PAD, BAR_BOTTOM - 22, logoEndX, BAR_BOTTOM, LOGO_A, LOGO_B));
+
+        // Wordmark gradient
+        sb.append(String.format("""
+                <linearGradient id="%s" gradientUnits="userSpaceOnUse"
+                    x1="39" y1="0" x2="79" y2="0">
+                  <stop offset="0%%" stop-color="%s"/>
+                  <stop offset="100%%" stop-color="%s"/>
+                </linearGradient>
+                """, wordmarkGradId, LOGO_A, LOGO_B));
+
+        // Clip path
+        sb.append(String.format("""
+                <clipPath id="%s">
+                  <rect x="0" y="0" width="%d" height="%d" rx="12" ry="12"/>
+                </clipPath>
+                """, clipId, W, H));
+
+        sb.append("</defs>\n");
+
+        // Background rect
+        sb.append(String.format(
+                "<rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" rx=\"12\" ry=\"12\" fill=\"url(#%s)\"/>\n",
+                W, H, bgId
+        ));
+
+        // Gloss + shimmer
+        sb.append(String.format("<g clip-path=\"url(#%s)\">\n", clipId));
+        sb.append(String.format(
+                "  <rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"url(#%s)\"/>\n",
+                W, H, glossId
+        ));
+        sb.append(String.format(
+                "  <rect class=\"%s\" x=\"-220\" y=\"0\" width=\"220\" height=\"%d\" fill=\"url(#%s-grad)\"/>\n",
+                shimId, H, shimId
+        ));
+        sb.append("</g>\n");
+
+        // Logo bars
+        for (int i = 0; i < BAR_SIZES.length; i++) {
+            int h = BAR_SIZES[i];
+            int x = PAD + i * (BAR_W_LOGO + BAR_GAP);
+            int y = BAR_BOTTOM - h;
+            sb.append(String.format(
+                    "<rect x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" rx=\"1.5\" fill=\"url(#%s)\"/>\n",
+                    x, y, BAR_W_LOGO, h, logoGradId
+            ));
+        }
+
+        // Wordmark "Solta"
+        int wordX = PAD + BAR_SIZES.length * (BAR_W_LOGO + BAR_GAP) + 1;
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"Outfit,'Noto Sans KR',system-ui,sans-serif\" font-size=\"14\" font-weight=\"700\" fill=\"url(#%s)\" letter-spacing=\"0.5\">Solta</text>\n",
+                wordX, BAR_BOTTOM - 2, wordmarkGradId
+        ));
+
+        // Username
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"11\" font-weight=\"400\" fill=\"%s\" text-anchor=\"end\">@%s</text>\n",
+                W - PAD, BAR_BOTTOM - 2, TEXT_SUB, escapeXml(username)
+        ));
+
+        // Horizontal rule
+        sb.append(String.format(
+                "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"%s\" stroke-width=\"1\"/>\n",
+                PAD, HEADER_H, W - PAD, HEADER_H, DIVIDER
+        ));
+
+        // ── Left panel ────────────────────────────────────────────────────────
+        // 총 풀이 시간 label
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"9\" font-weight=\"400\" fill=\"%s\">총 풀이 시간</text>\n",
+                PAD, HEADER_H + 34, TEXT_SUB
+        ));
+        // 총 풀이 시간 value
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"17\" font-weight=\"700\" fill=\"%s\">%s</text>\n",
+                PAD, HEADER_H + 54, TEXT, escapeXml(totalTimeStr)
+        ));
+
+        // 평균 풀이 시간 label
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"9\" font-weight=\"400\" fill=\"%s\">평균 풀이 시간</text>\n",
+                PAD, HEADER_H + 84, TEXT_SUB
+        ));
+        // 평균 풀이 시간 value
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"14\" font-weight=\"700\" fill=\"%s\">%d분</text>\n",
+                PAD, HEADER_H + 99, TEXT, avgMinutes
+        ));
+
+        // 자력 해결률 label
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"9\" font-weight=\"400\" fill=\"%s\">자력 해결률</text>\n",
+                PAD + 84, HEADER_H + 84, TEXT_SUB
+        ));
+        // 자력 해결률 value
+        sb.append(String.format(
+                "<text x=\"%d\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"14\" font-weight=\"700\" fill=\"%s\">%d%%</text>\n",
+                PAD + 84, HEADER_H + 99, TEXT, selfSolveRate
+        ));
+
+        // Vertical divider
+        sb.append(String.format(
+                "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" stroke=\"%s\" stroke-width=\"1\"/>\n",
+                DIV_X, HEADER_H + 10, DIV_X, H - 10, DIVIDER
+        ));
+
+        // ── Right panel: tier bar chart ───────────────────────────────────────
+        sb.append(String.format(
+                "<text x=\"%.1f\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"9\" font-weight=\"400\" fill=\"%s\">티어별 평균 풀이 시간</text>\n",
+                (double)(CHART_X + 4), HEADER_H + 15, TEXT_SUB
+        ));
+
+        for (int i = 0; i < active.size(); i++) {
+            TierBarData d = active.get(i);
+            double barH = Math.min((double) d.avgMinutes() / scalingMax * MAX_BAR_H, MAX_BAR_H);
+            double bX = chartOffX + CHART_GAP + i * (double) (BAR_W + CHART_GAP);
+            double bY = C_BOTTOM - barH;
+            double labelY = bY - 4;
+
+            // bar rect
+            sb.append(String.format(
+                    "<rect x=\"%.1f\" y=\"%.1f\" width=\"%d\" height=\"%.1f\" rx=\"3\" fill=\"%s\" opacity=\"0.9\"/>\n",
+                    bX, bY, BAR_W, barH, d.color()
+            ));
+            // value label above bar
+            sb.append(String.format(
+                    "<text x=\"%.1f\" y=\"%.1f\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"8\" font-weight=\"600\" fill=\"%s\" text-anchor=\"middle\" opacity=\"0.95\">%d분</text>\n",
+                    bX + BAR_W / 2.0, labelY, d.color(), d.avgMinutes()
+            ));
+            // tier label below bar
+            sb.append(String.format(
+                    "<text x=\"%.1f\" y=\"%d\" font-family=\"'Noto Sans KR',Outfit,system-ui,sans-serif\" font-size=\"8\" font-weight=\"500\" fill=\"%s\" text-anchor=\"middle\">%s</text>\n",
+                    bX + BAR_W / 2.0, C_BOTTOM + 12, TEXT_SUB, d.label()
+            ));
+        }
+
+        sb.append("</svg>");
+
+        return sb.toString();
+    }
+
+    private String escapeXml(String value) {
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/src/main/java/kr/solta/application/provided/BadgeReader.java
+++ b/src/main/java/kr/solta/application/provided/BadgeReader.java
@@ -1,0 +1,10 @@
+package kr.solta.application.provided;
+
+import kr.solta.application.provided.response.BadgeStatsResponse;
+
+public interface BadgeReader {
+
+    String generateBadgeSvg(String username);
+
+    BadgeStatsResponse getBadgeStats(String username);
+}

--- a/src/main/java/kr/solta/application/provided/response/BadgeStatsResponse.java
+++ b/src/main/java/kr/solta/application/provided/response/BadgeStatsResponse.java
@@ -1,0 +1,18 @@
+package kr.solta.application.provided.response;
+
+import java.util.List;
+
+public record BadgeStatsResponse(
+        String username,
+        int totalMinutes,
+        int avgMinutes,
+        int selfSolveRate,
+        List<TierDataItem> tierData
+) {
+
+    public record TierDataItem(
+            String label,
+            int avgMinutes,
+            String color
+    ) {}
+}

--- a/src/main/java/kr/solta/application/required/dto/BadgeSummaryStats.java
+++ b/src/main/java/kr/solta/application/required/dto/BadgeSummaryStats.java
@@ -1,0 +1,8 @@
+package kr.solta.application.required.dto;
+
+public record BadgeSummaryStats(
+        long totalSeconds,
+        double avgSeconds,
+        long solveCount
+) {
+}

--- a/src/main/java/kr/solta/application/required/dto/TierGroupStat.java
+++ b/src/main/java/kr/solta/application/required/dto/TierGroupStat.java
@@ -1,0 +1,9 @@
+package kr.solta.application.required.dto;
+
+import kr.solta.domain.Tier;
+
+public record TierGroupStat(
+        Tier tier,
+        double avgSeconds
+) {
+}


### PR DESCRIPTION
## Summary

GitHub 프로필 README에 Solta 풀이 통계를 배지 이미지로 공유할 수 있는 기능을 구현합니다.

### 왜 필요한가?
사용자가 자신의 백준 풀이 통계를 GitHub 프로필에 실시간으로 노출할 수 있도록 합니다. 마크다운 한 줄만 README에 추가하면 배지가 자동으로 업데이트됩니다.

### 동작 방식
1. `GET /api/badges/{username}` 요청 시 사용자 풀이 통계를 조회합니다.
2. 총 풀이 시간, 평균 풀이 시간, 자력 해결률, 티어 그룹별 평균 시간을 집계합니다.
3. `BadgeSvgGenerator`가 SVG 문자열을 생성하여 `image/svg+xml` 로 응답합니다.
4. GitHub README에 `[![Solta Stats](https://solta.kr/api/badges/{username})](https://solta.kr/profile/{username})` 형태로 삽입하면 클릭 시 프로필 페이지로 이동합니다.

## API

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/badges/{username}` | SVG 배지 이미지 반환 (`image/svg+xml`, `Access-Control-Allow-Origin: *`) |
| GET | `/api/badges/{username}/stats` | 배지 통계 JSON 반환 (FE 미리보기용) |

## 주요 변경 사항

- **`BadgeController`**: 뱃지 SVG 및 stats JSON 엔드포인트 추가. SVG 엔드포인트는 공개 리소스이므로 `@CrossOrigin(origins = "*")` 적용 및 `Cache-Control: no-cache` 헤더 설정
- **`BadgeService`**: 회원 조회 후 통계 집계, TierGroup별 label/color 매핑, `BadgeSvgGenerator` 호출
- **`BadgeSvgGenerator`**: 현재 FE 뱃지 디자인을 Java 문자열 템플릿으로 이식. shimmer 애니메이션, 로고 그라디언트, 티어 바 차트 포함
- **`BadgeReader`**: 뱃지 기능 in-port 인터페이스
- **`BadgeStatsResponse`**: 뱃지 stats JSON 응답 record DTO
- **`SolvedRepository`**: 뱃지 전용 집계 쿼리 3개 추가 (`findBadgeSummaryStats`, `findSelfSolveRate`, `findBadgeTierGroupStats`)
- **`BadgeSummaryStats` / `TierGroupStat`**: 집계 쿼리 결과 record DTO