### PR TITLE
feat: 활동 히트맵 및 스트릭 API 구현

### DIFF
--- a/src/main/java/kr/solta/adapter/webapi/MemberController.java
+++ b/src/main/java/kr/solta/adapter/webapi/MemberController.java
@@ -1,11 +1,14 @@
 package kr.solta.adapter.webapi;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import kr.solta.adapter.webapi.resolver.Auth;
 import kr.solta.adapter.webapi.response.MemberResponse;
 import kr.solta.adapter.webapi.response.MemberSearchResponse;
+import kr.solta.application.provided.ActivityReader;
 import kr.solta.application.provided.MemberReader;
 import kr.solta.application.provided.SolvedStatisticsReader;
+import kr.solta.application.provided.response.ActivityHeatmapResponse;
 import kr.solta.application.provided.request.AuthMember;
 import kr.solta.application.provided.request.TagKey;
 import kr.solta.application.provided.response.IndependentSolveTrendsResponse;
@@ -16,6 +19,7 @@ import kr.solta.domain.Member;
 import kr.solta.domain.SolvedPeriod;
 import kr.solta.domain.TierGroup;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,6 +34,7 @@ public class MemberController {
 
     private final MemberReader memberReader;
     private final SolvedStatisticsReader solvedStatisticsReader;
+    private final ActivityReader activityReader;
 
     @GetMapping("/search")
     public ResponseEntity<MemberSearchResponse> searchMembers(
@@ -71,6 +76,15 @@ public class MemberController {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/activity/heatmap/search")
+    public ResponseEntity<ActivityHeatmapResponse> getActivityHeatmap(
+            @RequestParam final String name,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) final LocalDate endDate
+    ) {
+        return ResponseEntity.ok(activityReader.getActivityHeatmap(name, startDate, endDate));
     }
 
     @GetMapping("/{name}/independent-solve-trends")

--- a/src/main/java/kr/solta/application/ActivityService.java
+++ b/src/main/java/kr/solta/application/ActivityService.java
@@ -1,0 +1,47 @@
+package kr.solta.application;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.time.format.DateTimeFormatter;
+import kr.solta.application.provided.ActivityReader;
+import kr.solta.application.provided.response.ActivityData;
+import kr.solta.application.provided.response.ActivityHeatmapResponse;
+import kr.solta.application.required.MemberRepository;
+import kr.solta.application.required.SolvedRepository;
+import kr.solta.application.required.dto.DailyActivity;
+import kr.solta.domain.ActivityCalendar;
+import kr.solta.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityService implements ActivityReader {
+
+    private final MemberRepository memberRepository;
+    private final SolvedRepository solvedRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public ActivityHeatmapResponse getActivityHeatmap(final String name, final LocalDate startDate, final LocalDate endDate) {
+        Member member = memberRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다. name: " + name));
+
+        List<DailyActivity> rawActivities = solvedRepository.findDailyActivityByMemberIdBetween(member.getId(), startDate, endDate);
+        List<ActivityData> activities = new ArrayList<>();
+        for (DailyActivity raw : rawActivities) {
+            activities.add(new ActivityData(raw.date(), raw.count(), raw.totalSeconds(), raw.independentCount()));
+        }
+
+        List<String> rawDates = solvedRepository.findDistinctSolvedDatesByMemberId(member.getId());
+        List<LocalDate> allDates = new ArrayList<>();
+        for (final String raw : rawDates) {
+            allDates.add(LocalDate.parse(raw, DateTimeFormatter.ISO_LOCAL_DATE));
+        }
+        ActivityCalendar calendar = new ActivityCalendar(allDates);
+
+        return new ActivityHeatmapResponse(activities, calendar.currentStreak(), calendar.longestStreak());
+    }
+}

--- a/src/main/java/kr/solta/application/provided/ActivityReader.java
+++ b/src/main/java/kr/solta/application/provided/ActivityReader.java
@@ -1,0 +1,9 @@
+package kr.solta.application.provided;
+
+import java.time.LocalDate;
+import kr.solta.application.provided.response.ActivityHeatmapResponse;
+
+public interface ActivityReader {
+
+    ActivityHeatmapResponse getActivityHeatmap(final String name, final LocalDate startDate, final LocalDate endDate);
+}

--- a/src/main/java/kr/solta/application/provided/response/ActivityData.java
+++ b/src/main/java/kr/solta/application/provided/response/ActivityData.java
@@ -1,0 +1,4 @@
+package kr.solta.application.provided.response;
+
+public record ActivityData(String date, long count, long totalSeconds, long independentCount) {
+}

--- a/src/main/java/kr/solta/application/provided/response/ActivityHeatmapResponse.java
+++ b/src/main/java/kr/solta/application/provided/response/ActivityHeatmapResponse.java
@@ -1,0 +1,10 @@
+package kr.solta.application.provided.response;
+
+import java.util.List;
+
+public record ActivityHeatmapResponse(
+        List<ActivityData> activities,
+        int currentStreak,
+        int longestStreak
+) {
+}

--- a/src/main/java/kr/solta/application/required/SolvedRepository.java
+++ b/src/main/java/kr/solta/application/required/SolvedRepository.java
@@ -1,8 +1,10 @@
 package kr.solta.application.required;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import kr.solta.application.required.dto.AllSolvedAverage;
+import kr.solta.application.required.dto.DailyActivity;
 import kr.solta.application.required.dto.BadgeSummaryStats;
 import kr.solta.application.required.dto.DistributionBucketData;
 import kr.solta.application.required.dto.IndependentRatioData;
@@ -425,4 +427,28 @@ public interface SolvedRepository extends JpaRepository<Solved, Long> {
                 AND s.solveTimeSeconds > :solveTimeSeconds
             """)
     long countSlowerSolvers(Problem problem, int solveTimeSeconds);
+
+    @Query("""
+                SELECT DISTINCT CAST(FUNCTION('DATE_FORMAT', s.solvedTime, '%Y-%m-%d') AS string)
+                FROM Solved s
+                WHERE s.member.id = :memberId
+                ORDER BY CAST(FUNCTION('DATE_FORMAT', s.solvedTime, '%Y-%m-%d') AS string) ASC
+            """)
+    List<String> findDistinctSolvedDatesByMemberId(Long memberId);
+
+    @Query("""
+                SELECT new kr.solta.application.required.dto.DailyActivity(
+                    CAST(FUNCTION('DATE_FORMAT', s.solvedTime, '%Y-%m-%d') AS string),
+                    COUNT(s.id),
+                    COALESCE(SUM(s.solveTimeSeconds), 0),
+                    COALESCE(SUM(CASE WHEN s.solveType = kr.solta.domain.SolveType.SELF THEN 1 ELSE 0 END), 0)
+                )
+                FROM Solved s
+                WHERE s.member.id = :memberId
+                AND CAST(s.solvedTime AS date) >= :startDate
+                AND CAST(s.solvedTime AS date) <= :endDate
+                GROUP BY CAST(FUNCTION('DATE_FORMAT', s.solvedTime, '%Y-%m-%d') AS string)
+                ORDER BY CAST(FUNCTION('DATE_FORMAT', s.solvedTime, '%Y-%m-%d') AS string) ASC
+            """)
+    List<DailyActivity> findDailyActivityByMemberIdBetween(Long memberId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/kr/solta/application/required/dto/DailyActivity.java
+++ b/src/main/java/kr/solta/application/required/dto/DailyActivity.java
@@ -1,0 +1,4 @@
+package kr.solta.application.required.dto;
+
+public record DailyActivity(String date, Long count, Long totalSeconds, Long independentCount) {
+}

--- a/src/main/java/kr/solta/domain/ActivityCalendar.java
+++ b/src/main/java/kr/solta/domain/ActivityCalendar.java
@@ -1,0 +1,43 @@
+package kr.solta.domain;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ActivityCalendar {
+
+    private final List<LocalDate> sortedDates;
+
+    public ActivityCalendar(final List<LocalDate> sortedDates) {
+        this.sortedDates = sortedDates;
+    }
+
+    public int currentStreak() {
+        Set<LocalDate> dateSet = new HashSet<>(sortedDates);
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = dateSet.contains(today) ? today : today.minusDays(1);
+        int streak = 0;
+        LocalDate cursor = startDate;
+        while (dateSet.contains(cursor)) {
+            streak++;
+            cursor = cursor.minusDays(1);
+        }
+        return streak;
+    }
+
+    public int longestStreak() {
+        if (sortedDates.isEmpty()) return 0;
+        int longest = 1;
+        int current = 1;
+        for (int i = 1; i < sortedDates.size(); i++) {
+            if (sortedDates.get(i).minusDays(1).equals(sortedDates.get(i - 1))) {
+                current++;
+                if (current > longest) longest = current;
+            } else {
+                current = 1;
+            }
+        }
+        return longest;
+    }
+}

--- a/src/test/java/kr/solta/application/provided/ActivityReaderTest.java
+++ b/src/test/java/kr/solta/application/provided/ActivityReaderTest.java
@@ -1,0 +1,174 @@
+package kr.solta.application.provided;
+
+import static kr.solta.support.TestFixtures.createMember;
+import static kr.solta.support.TestFixtures.createProblem;
+import static kr.solta.support.TestFixtures.createSolved;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import kr.solta.application.provided.response.ActivityHeatmapResponse;
+import kr.solta.application.required.MemberRepository;
+import kr.solta.application.required.ProblemRepository;
+import kr.solta.application.required.SolvedRepository;
+import kr.solta.domain.Member;
+import kr.solta.domain.Problem;
+import kr.solta.domain.SolveType;
+import kr.solta.support.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ActivityReaderTest extends IntegrationTest {
+
+    @Autowired
+    private ActivityReader activityReader;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private SolvedRepository solvedRepository;
+
+    @Test
+    void 날짜_범위_내_활동이_있는_날만_반환한다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "testUser"));
+        Problem problem = problemRepository.save(createProblem("문제", 1000L));
+
+        solvedRepository.save(createSolved(3600, SolveType.SELF, member, problem,
+                LocalDateTime.of(2025, 3, 1, 10, 0)));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem,
+                LocalDateTime.of(2025, 3, 3, 14, 0)));
+        solvedRepository.save(createSolved(1200, SolveType.SELF, member, problem,
+                LocalDateTime.of(2025, 2, 28, 9, 0)));  // 범위 밖
+
+        //when
+        ActivityHeatmapResponse response = activityReader.getActivityHeatmap(
+                "testUser",
+                LocalDate.of(2025, 3, 1),
+                LocalDate.of(2025, 3, 31)
+        );
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(response.activities()).hasSize(2);
+            softly.assertThat(response.activities().get(0).date()).isEqualTo("2025-03-01");
+            softly.assertThat(response.activities().get(0).count()).isEqualTo(1);
+            softly.assertThat(response.activities().get(0).totalSeconds()).isEqualTo(3600);
+            softly.assertThat(response.activities().get(1).date()).isEqualTo("2025-03-03");
+        });
+    }
+
+    @Test
+    void 같은_날_여러_풀이는_집계된다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "testUser"));
+        Problem problem1 = problemRepository.save(createProblem("문제1", 1000L));
+        Problem problem2 = problemRepository.save(createProblem("문제2", 1001L));
+
+        LocalDateTime sameDay = LocalDateTime.of(2025, 5, 10, 10, 0);
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem1, sameDay));
+        solvedRepository.save(createSolved(2400, SolveType.SELF, member, problem2, sameDay.plusHours(2)));
+
+        //when
+        ActivityHeatmapResponse response = activityReader.getActivityHeatmap(
+                "testUser",
+                LocalDate.of(2025, 5, 1),
+                LocalDate.of(2025, 5, 31)
+        );
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(response.activities()).hasSize(1);
+            softly.assertThat(response.activities().get(0).count()).isEqualTo(2);
+            softly.assertThat(response.activities().get(0).totalSeconds()).isEqualTo(4200);
+        });
+    }
+
+    @Test
+    void 오늘까지_연속으로_풀었으면_currentStreak를_계산한다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "testUser"));
+        Problem problem = problemRepository.save(createProblem("문제", 1000L));
+
+        LocalDate today = LocalDate.now();
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, today.minusDays(2).atStartOfDay()));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, today.minusDays(1).atStartOfDay()));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, today.atStartOfDay()));
+
+        //when
+        ActivityHeatmapResponse response = activityReader.getActivityHeatmap(
+                "testUser",
+                today.minusDays(30),
+                today
+        );
+
+        //then
+        assertThat(response.currentStreak()).isEqualTo(3);
+    }
+
+    @Test
+    void 최장_스트릭을_계산한다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "testUser"));
+        Problem problem = problemRepository.save(createProblem("문제", 1000L));
+
+        // 3일 연속
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 1, 1, 10, 0)));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 1, 2, 10, 0)));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 1, 3, 10, 0)));
+        // 5일 연속
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 2, 1, 10, 0)));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 2, 2, 10, 0)));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 2, 3, 10, 0)));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 2, 4, 10, 0)));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem, LocalDateTime.of(2025, 2, 5, 10, 0)));
+
+        //when
+        ActivityHeatmapResponse response = activityReader.getActivityHeatmap(
+                "testUser",
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+        );
+
+        //then
+        assertThat(response.longestStreak()).isEqualTo(5);
+    }
+
+    @Test
+    void 활동이_없는_경우_빈_목록과_스트릭_0을_반환한다() {
+        //given
+        memberRepository.save(createMember(1L, "testUser"));
+
+        //when
+        ActivityHeatmapResponse response = activityReader.getActivityHeatmap(
+                "testUser",
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+        );
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(response.activities()).isEmpty();
+            softly.assertThat(response.currentStreak()).isEqualTo(0);
+            softly.assertThat(response.longestStreak()).isEqualTo(0);
+        });
+    }
+
+    @Test
+    void 존재하지_않는_사용자_조회시_예외가_발생한다() {
+        //when & then
+        assertThatThrownBy(() -> activityReader.getActivityHeatmap(
+                "notExist",
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("회원을 찾을 수 없습니다");
+    }
+}

--- a/src/test/java/kr/solta/domain/ActivityCalendarTest.java
+++ b/src/test/java/kr/solta/domain/ActivityCalendarTest.java
@@ -1,0 +1,100 @@
+package kr.solta.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ActivityCalendarTest {
+
+    @Test
+    void 오늘_풀이가_있으면_오늘부터_연속_카운트한다() {
+        //given
+        LocalDate today = LocalDate.now();
+        List<LocalDate> dates = List.of(today.minusDays(2), today.minusDays(1), today);
+        ActivityCalendar calendar = new ActivityCalendar(dates);
+
+        //when & then
+        assertThat(calendar.currentStreak()).isEqualTo(3);
+    }
+
+    @Test
+    void 오늘_풀이가_없으면_어제부터_연속_카운트한다() {
+        //given
+        LocalDate today = LocalDate.now();
+        List<LocalDate> dates = List.of(today.minusDays(3), today.minusDays(2), today.minusDays(1));
+        ActivityCalendar calendar = new ActivityCalendar(dates);
+
+        //when & then
+        assertThat(calendar.currentStreak()).isEqualTo(3);
+    }
+
+    @Test
+    void 오늘도_어제도_풀이가_없으면_스트릭은_0이다() {
+        //given
+        LocalDate today = LocalDate.now();
+        List<LocalDate> dates = List.of(today.minusDays(5), today.minusDays(4));
+        ActivityCalendar calendar = new ActivityCalendar(dates);
+
+        //when & then
+        assertThat(calendar.currentStreak()).isEqualTo(0);
+    }
+
+    @Test
+    void 풀이_기록이_없으면_스트릭은_모두_0이다() {
+        //given
+        ActivityCalendar calendar = new ActivityCalendar(List.of());
+
+        //when & then
+        assertSoftly(softly -> {
+            softly.assertThat(calendar.currentStreak()).isEqualTo(0);
+            softly.assertThat(calendar.longestStreak()).isEqualTo(0);
+        });
+    }
+
+    @Test
+    void 최장_스트릭을_정확히_계산한다() {
+        //given
+        List<LocalDate> dates = List.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 1, 2),
+                LocalDate.of(2025, 1, 3),  // 3일 연속
+                LocalDate.of(2025, 1, 10),
+                LocalDate.of(2025, 1, 11),
+                LocalDate.of(2025, 1, 12),
+                LocalDate.of(2025, 1, 13),
+                LocalDate.of(2025, 1, 14)  // 5일 연속
+        );
+        ActivityCalendar calendar = new ActivityCalendar(dates);
+
+        //when & then
+        assertThat(calendar.longestStreak()).isEqualTo(5);
+    }
+
+    @Test
+    void 하루만_풀었어도_최장_스트릭은_1이다() {
+        //given
+        ActivityCalendar calendar = new ActivityCalendar(List.of(LocalDate.of(2025, 3, 15)));
+
+        //when & then
+        assertThat(calendar.longestStreak()).isEqualTo(1);
+    }
+
+    @Test
+    void 모두_연속된_날이면_전체_기간이_최장_스트릭이다() {
+        //given
+        List<LocalDate> dates = List.of(
+                LocalDate.of(2025, 2, 1),
+                LocalDate.of(2025, 2, 2),
+                LocalDate.of(2025, 2, 3),
+                LocalDate.of(2025, 2, 4),
+                LocalDate.of(2025, 2, 5)
+        );
+        ActivityCalendar calendar = new ActivityCalendar(dates);
+
+        //when & then
+        assertThat(calendar.longestStreak()).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
## Summary

사용자의 풀이 활동을 날짜별로 집계하여 히트맵 및 스트릭 정보를 제공하는 API를 구현합니다.

### 왜 필요한가?
프로필 페이지에서 연간 풀이 활동을 시각화하고, 연속 풀이 스트릭을 확인할 수 있도록 합니다. GitHub 잔디처럼 날짜별 활동 강도를 보여줘 풀이 습관 형성을 돕습니다.

### 동작 방식
1. `GET /api/members/activity/heatmap/search?name={username}&startDate={date}&endDate={date}` 요청 시 해당 기간의 일별 활동을 집계합니다.
2. `SolvedRepository`에서 날짜별 문제 수, 총 풀이 시간, 독립 풀이 수를 GROUP BY로 집계합니다.
3. 전체 풀이 날짜를 조회해 `ActivityCalendar` 도메인 객체로 현재 스트릭 / 최장 스트릭을 계산합니다.
4. 빈 날짜 채우기는 클라이언트가 담당하며, 백엔드는 활동이 있는 날짜만 반환합니다.

## API

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/members/activity/heatmap/search` | 날짜 범위별 일별 활동 + 스트릭 반환 |

### Response
```json
{
  "activities": [
    { "date": "2025-03-15", "count": 3, "totalSeconds": 2820, "independentCount": 2 }
  ],
  "currentStreak": 14,
  "longestStreak": 32
}
```

## 주요 변경 사항

- **`ActivityCalendar`** (domain): 풀이 날짜 목록을 받아 현재 스트릭·최장 스트릭을 계산하는 도메인 Value Object. 오늘 풀이가 없으면 어제까지 기준으로 유예 처리
- **`ActivityService`** (application): `SolvedRepository`에서 일별 활동 집계 후 `ActivityCalendar`로 스트릭 계산
- **`SolvedRepository`** (required): `DATE_FORMAT`을 사용해 날짜별 count / totalSeconds / independentCount 집계 쿼리 추가. Hibernate 6의 `CAST(... AS date)` → `java.sql.Date` 타입 불일치 이슈로 문자열 변환 방식 적용
- **`ActivityReader`** (provided): 히트맵 기능 in-port 인터페이스
- **`ActivityData` / `ActivityHeatmapResponse`** (provided/response): 응답 DTO
- **`DailyActivity`** (required/dto): Repository → Service 전달용 날짜별 집계 record
- **`MemberController`**: `/activity/heatmap/search` 엔드포인트 추가

## 테스트

- **`ActivityCalendarTest`**: 스트릭 계산 로직 단위 테스트 (오늘 풀이 O/X, 연속 없음, 최장 스트릭 등)
- **`ActivityReaderTest`**: TestContainers 기반 통합 테스트. 활동 데이터 적재 후 날짜 범위 필터링, 스트릭 계산 검증

## Test plan
- [x] `./gradlew test --tests "*ActivityCalendarTest"` 통과 확인
- [x] `./gradlew test --tests "*ActivityReaderTest"` 통과 확인
- [x] `GET /api/members/activity/heatmap/search?name=abc5259&startDate=2025-01-01&endDate=2025-12-31` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)