### PR TITLE
feat: 홈 화면 소셜 피드 API 구현

### DIFF
--- a/src/main/java/kr/solta/adapter/webapi/FeedController.java
+++ b/src/main/java/kr/solta/adapter/webapi/FeedController.java
@@ -1,0 +1,21 @@
+package kr.solta.adapter.webapi;
+
+import kr.solta.application.provided.FeedReader;
+import kr.solta.application.provided.response.FeedResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedReader feedReader;
+
+    @GetMapping("/recent")
+    public FeedResponse getRecentFeed() {
+        return feedReader.getRecentFeed();
+    }
+}

--- a/src/main/java/kr/solta/application/FeedService.java
+++ b/src/main/java/kr/solta/application/FeedService.java
@@ -1,0 +1,54 @@
+package kr.solta.application;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.solta.application.provided.FeedReader;
+import kr.solta.application.provided.response.FeedItemResponse;
+import kr.solta.application.provided.response.FeedResponse;
+import kr.solta.application.provided.response.FeedStatsResponse;
+import kr.solta.application.required.SolvedRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.temporal.TemporalAdjusters;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedService implements FeedReader {
+
+    private static final int FEED_SIZE = 10;
+
+    private final SolvedRepository solvedRepository;
+
+    @Override
+    public FeedResponse getRecentFeed() {
+        LocalDateTime weekStart = LocalDateTime.now().minusDays(7);
+
+        long activeUserCount = solvedRepository.countDistinctMembersFromTime(weekStart);
+        long totalSolveCount = solvedRepository.countSolvesFromTime(weekStart);
+
+        FeedStatsResponse stats = new FeedStatsResponse("최근 1주일", activeUserCount, totalSolveCount);
+
+        List<FeedItemResponse> recentFeeds = solvedRepository
+                .findRecentSolvesWithDetails(PageRequest.of(0, FEED_SIZE))
+                .stream()
+                .map(s -> new FeedItemResponse(
+                        s.getMember().getName(),
+                        s.getMember().getAvatarUrl(),
+                        s.getProblem().getBojProblemId(),
+                        s.getProblem().getTitle(),
+                        s.getProblem().getTier().name(),
+                        s.getSolveType().name(),
+                        s.getSolveTimeSeconds(),
+                        s.getSolvedTime()
+                ))
+                .toList();
+
+        return new FeedResponse(stats, recentFeeds);
+    }
+}

--- a/src/main/java/kr/solta/application/provided/FeedReader.java
+++ b/src/main/java/kr/solta/application/provided/FeedReader.java
@@ -1,0 +1,7 @@
+package kr.solta.application.provided;
+
+import kr.solta.application.provided.response.FeedResponse;
+
+public interface FeedReader {
+    FeedResponse getRecentFeed();
+}

--- a/src/main/java/kr/solta/application/provided/response/FeedItemResponse.java
+++ b/src/main/java/kr/solta/application/provided/response/FeedItemResponse.java
@@ -1,0 +1,16 @@
+package kr.solta.application.provided.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FeedItemResponse(
+        String memberName,
+        String memberAvatarUrl,
+        long problemBojId,
+        String problemTitle,
+        String problemTier,
+        String solveType,
+        Integer solveTimeSeconds,
+        LocalDateTime solvedAt
+) {}

--- a/src/main/java/kr/solta/application/provided/response/FeedResponse.java
+++ b/src/main/java/kr/solta/application/provided/response/FeedResponse.java
@@ -1,0 +1,8 @@
+package kr.solta.application.provided.response;
+
+import java.util.List;
+
+public record FeedResponse(
+        FeedStatsResponse stats,
+        List<FeedItemResponse> recentFeeds
+) {}

--- a/src/main/java/kr/solta/application/provided/response/FeedStatsResponse.java
+++ b/src/main/java/kr/solta/application/provided/response/FeedStatsResponse.java
@@ -1,0 +1,7 @@
+package kr.solta.application.provided.response;
+
+public record FeedStatsResponse(
+        String periodLabel,
+        long activeUserCount,
+        long totalSolveCount
+) {}

--- a/src/main/java/kr/solta/application/required/SolvedRepository.java
+++ b/src/main/java/kr/solta/application/required/SolvedRepository.java
@@ -20,9 +20,11 @@ import kr.solta.domain.Solved;
 import kr.solta.domain.SolvedAverage;
 import kr.solta.domain.Tier;
 import kr.solta.domain.TierAverage;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SolvedRepository extends JpaRepository<Solved, Long> {
 
@@ -451,4 +453,13 @@ public interface SolvedRepository extends JpaRepository<Solved, Long> {
                 ORDER BY CAST(FUNCTION('DATE_FORMAT', s.solvedTime, '%Y-%m-%d') AS string) ASC
             """)
     List<DailyActivity> findDailyActivityByMemberIdBetween(Long memberId, LocalDate startDate, LocalDate endDate);
+
+    @Query("SELECT COUNT(DISTINCT s.member.id) FROM Solved s WHERE s.solvedTime >= :weekStart")
+    long countDistinctMembersFromTime(@Param("weekStart") LocalDateTime weekStart);
+
+    @Query("SELECT COUNT(s) FROM Solved s WHERE s.solvedTime >= :weekStart")
+    long countSolvesFromTime(@Param("weekStart") LocalDateTime weekStart);
+
+    @Query("SELECT s FROM Solved s JOIN FETCH s.member m JOIN FETCH s.problem p ORDER BY s.solvedTime DESC")
+    List<Solved> findRecentSolvesWithDetails(Pageable pageable);
 }

--- a/src/test/java/kr/solta/application/FeedReaderTest.java
+++ b/src/test/java/kr/solta/application/FeedReaderTest.java
@@ -1,0 +1,156 @@
+package kr.solta.application;
+
+import static kr.solta.support.TestFixtures.createMember;
+import static kr.solta.support.TestFixtures.createProblem;
+import static kr.solta.support.TestFixtures.createSolved;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDateTime;
+import kr.solta.application.provided.FeedReader;
+import kr.solta.application.provided.response.FeedItemResponse;
+import kr.solta.application.provided.response.FeedResponse;
+import kr.solta.application.required.MemberRepository;
+import kr.solta.application.required.ProblemRepository;
+import kr.solta.application.required.SolvedRepository;
+import kr.solta.domain.Member;
+import kr.solta.domain.Problem;
+import kr.solta.domain.SolveType;
+import kr.solta.domain.Tier;
+import kr.solta.support.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class FeedReaderTest extends IntegrationTest {
+
+    @Autowired
+    private FeedReader feedReader;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private SolvedRepository solvedRepository;
+
+    @Test
+    void 최근_풀이_피드를_조회할_수_있다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "alice"));
+        Problem problem = problemRepository.save(createProblem("두 수의 합", 1000L, Tier.S1));
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem));
+
+        //when
+        FeedResponse response = feedReader.getRecentFeed();
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(response.recentFeeds()).hasSize(1);
+
+            FeedItemResponse item = response.recentFeeds().get(0);
+            softly.assertThat(item.memberName()).isEqualTo("alice");
+            softly.assertThat(item.problemBojId()).isEqualTo(1000L);
+            softly.assertThat(item.problemTitle()).isEqualTo("두 수의 합");
+            softly.assertThat(item.problemTier()).isEqualTo("S1");
+            softly.assertThat(item.solveType()).isEqualTo("SELF");
+        });
+    }
+
+    @Test
+    void SELF와_SOLUTION_풀이_모두_피드에_포함된다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "bob"));
+        Problem problem1 = problemRepository.save(createProblem("문제A", 2000L, Tier.B3));
+        Problem problem2 = problemRepository.save(createProblem("문제B", 2001L, Tier.G2));
+        solvedRepository.save(createSolved(3600, SolveType.SELF, member, problem1));
+        solvedRepository.save(createSolved(0, SolveType.SOLUTION, member, problem2));
+
+        //when
+        FeedResponse response = feedReader.getRecentFeed();
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(response.recentFeeds()).hasSize(2);
+
+            assertThat(response.recentFeeds())
+                    .extracting(FeedItemResponse::solveType)
+                    .containsExactlyInAnyOrder("SELF", "SOLUTION");
+        });
+    }
+
+    @Test
+    void 최근_1주일_통계가_집계된다() {
+        //given
+        Member member1 = memberRepository.save(createMember(1L, "charlie"));
+        Member member2 = memberRepository.save(createMember(2L, "diana"));
+        Problem problem1 = problemRepository.save(createProblem("문제1", 3000L, Tier.S3));
+        Problem problem2 = problemRepository.save(createProblem("문제2", 3001L, Tier.G5));
+        Problem problem3 = problemRepository.save(createProblem("문제3", 3002L, Tier.B1));
+
+        solvedRepository.save(createSolved(1200, SolveType.SELF, member1, problem1));
+        solvedRepository.save(createSolved(2400, SolveType.SELF, member2, problem2));
+        solvedRepository.save(createSolved(600, SolveType.SELF, member1, problem3,
+                LocalDateTime.now().minusDays(10)));
+
+        //when
+        FeedResponse response = feedReader.getRecentFeed();
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(response.stats().periodLabel()).isEqualTo("최근 1주일");
+            softly.assertThat(response.stats().activeUserCount()).isEqualTo(2L);
+            softly.assertThat(response.stats().totalSolveCount()).isEqualTo(2L);
+        });
+    }
+
+    @Test
+    void 풀이가_없으면_빈_피드를_반환한다() {
+        //when
+        FeedResponse response = feedReader.getRecentFeed();
+
+        //then
+        assertSoftly(softly -> {
+            softly.assertThat(response.recentFeeds()).isEmpty();
+            softly.assertThat(response.stats().activeUserCount()).isEqualTo(0L);
+            softly.assertThat(response.stats().totalSolveCount()).isEqualTo(0L);
+        });
+    }
+
+    @Test
+    void 최대_10개_풀이만_반환된다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "eve"));
+        for (int i = 0; i < 12; i++) {
+            Problem problem = problemRepository.save(createProblem("문제" + i, 4000L + i, Tier.B1));
+            solvedRepository.save(createSolved(600, SolveType.SELF, member, problem));
+        }
+
+        //when
+        FeedResponse response = feedReader.getRecentFeed();
+
+        //then
+        assertThat(response.recentFeeds()).hasSize(10);
+    }
+
+    @Test
+    void 피드는_최신순으로_정렬된다() {
+        //given
+        Member member = memberRepository.save(createMember(1L, "frank"));
+        Problem problem1 = problemRepository.save(createProblem("오래된 문제", 5000L, Tier.S2));
+        Problem problem2 = problemRepository.save(createProblem("최신 문제", 5001L, Tier.G1));
+
+        solvedRepository.save(createSolved(1800, SolveType.SELF, member, problem1,
+                LocalDateTime.now().minusHours(5)));
+        solvedRepository.save(createSolved(900, SolveType.SELF, member, problem2,
+                LocalDateTime.now().minusHours(1)));
+
+        //when
+        FeedResponse response = feedReader.getRecentFeed();
+
+        //then
+        assertThat(response.recentFeeds()).hasSize(2);
+        assertThat(response.recentFeeds().get(0).problemBojId()).isEqualTo(5001L);
+    }
+}


### PR DESCRIPTION
## Summary

홈 화면의 소셜 피드를 위한 `GET /api/feed/recent` 엔드포인트를 구현합니다.

### 왜 필요한가?
현재 홈 화면은 기능 소개 + CTA 버튼만 존재해 처음 방문한 사용자에게 "실제 사용자가 있는가?"라는 신뢰를 줄 수 없습니다. 실제 풀이 데이터를 보여주는 소셜 피드를 추가해 전환율을 높입니다.

### 동작 방식
1. `GET /api/feed/recent` 요청 시 최근 1주일 통계(참여 인원, 풀이 수)와 최근 10개 풀이를 반환합니다.
2. 통계는 `SolvedRepository`에 추가한 집계 쿼리로 최근 7일 기준으로 계산합니다.
3. 피드는 SELF / SOLUTION 타입 모두 포함하며, `solvedTime` 기준 최신순으로 정렬합니다.
4. 인증 없이 접근 가능한 공개 엔드포인트입니다.

## API

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/feed/recent` | 최근 1주일 통계 + 최근 풀이 10개 반환 |

### Response
```json
{
  "stats": {
    "periodLabel": "최근 1주일",
    "activeUserCount": 12,
    "totalSolveCount": 89
  },
  "recentFeeds": [
    {
      "memberName": "abc",
      "memberAvatarUrl": "https://avatars.githubusercontent.com/...",
      "problemBojId": 1234,
      "problemTitle": "세그먼트 트리",
      "problemTier": "G5",
      "solveType": "SELF",
      "solveTimeSeconds": 1952,
      "solvedAt": "2026-02-24T10:30:00"
    }
  ]
}
```

## 주요 변경 사항

- **`FeedController`** (adapter/webapi): `GET /api/feed/recent` 엔드포인트. 인증 불필요
- **`FeedService`** (application): 최근 7일 집계 쿼리 호출 후 `FeedResponse` 조립
- **`FeedReader`** (provided): 피드 기능 in-port 인터페이스
- **`FeedStatsResponse`** (provided/response): 통계 응답 DTO (`periodLabel`, `activeUserCount`, `totalSolveCount`)
- **`FeedItemResponse`** (provided/response): 풀이 아이템 응답 DTO (`memberName`, `memberAvatarUrl`, `problemTier`, `solveType`, `solveTimeSeconds`, `solvedAt` 등)
- **`FeedResponse`** (provided/response): 통계 + 피드 리스트 래퍼 DTO
- **`SolvedRepository`** (required): 피드용 쿼리 3개 추가
  - `countDistinctMembersFromTime` — 특정 시각 이후 활성 유저 수
  - `countSolvesFromTime` — 특정 시각 이후 총 풀이 수
  - `findRecentSolvesWithDetails` — member/problem JOIN FETCH, 최신순 N개

## 테스트

- **`FeedReaderTest`**: TestContainers 기반 통합 테스트 6개
  - 기본 피드 조회 및 응답 필드 검증
  - SELF / SOLUTION 타입 모두 포함 확인
  - 최근 1주일 통계 집계 및 오래된 풀이 제외 검증
  - 데이터 없을 때 빈 응답 반환
  - FEED_SIZE=10 제한 검증
  - 최신순 정렬 검증

## Test plan
- [x] `./gradlew test --tests "*FeedReaderTest"` 통과 확인
- [x] `./gradlew compileJava` 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)