### PR TITLE
feat: 메모 본인만 조회 가능하도록 수정

### DIFF
--- a/src/main/java/kr/solta/adapter/webapi/SolvedController.java
+++ b/src/main/java/kr/solta/adapter/webapi/SolvedController.java
@@ -61,11 +61,15 @@ public class SolvedController {
     }
 
     @GetMapping("/members/solveds/search")
-    public ResponseEntity<List<RecentSolvedResponse>> findSolvedWithAverages(@RequestParam final String name) {
+    public ResponseEntity<List<RecentSolvedResponse>> findSolvedWithAverages(
+            @RequestParam final String name,
+            @Auth(required = false) final AuthMember authMember
+    ) {
         List<SolvedWithTags> solvedWithTags = solvedFinder.findSolvedWithTags(name);
+        Long viewerMemberId = authMember != null ? authMember.memberId() : null;
 
         List<RecentSolvedResponse> recentSolvedResponses = solvedWithTags.stream()
-                .map(RecentSolvedResponse::from)
+                .map(s -> RecentSolvedResponse.from(s, viewerMemberId))
                 .toList();
 
         return ResponseEntity.ok(recentSolvedResponses);
@@ -94,12 +98,14 @@ public class SolvedController {
     @GetMapping("/members/solveds/retry/search")
     public ResponseEntity<List<RecentSolvedResponse>> findProblemsToRetry(
             @RequestParam final String name,
-            @RequestParam(defaultValue = "LATEST") final SolvedSortType sortType
+            @RequestParam(defaultValue = "LATEST") final SolvedSortType sortType,
+            @Auth(required = false) final AuthMember authMember
     ) {
         List<SolvedWithTags> solvedWithTags = solvedFinder.findProblemsToRetry(name, sortType);
+        Long viewerMemberId = authMember != null ? authMember.memberId() : null;
 
         List<RecentSolvedResponse> recentSolvedResponses = solvedWithTags.stream()
-                .map(RecentSolvedResponse::from)
+                .map(s -> RecentSolvedResponse.from(s, viewerMemberId))
                 .toList();
 
         return ResponseEntity.ok(recentSolvedResponses);

--- a/src/main/java/kr/solta/adapter/webapi/resolver/Auth.java
+++ b/src/main/java/kr/solta/adapter/webapi/resolver/Auth.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Auth {
+    boolean required() default true;
 }

--- a/src/main/java/kr/solta/adapter/webapi/resolver/AuthArgumentResolver.java
+++ b/src/main/java/kr/solta/adapter/webapi/resolver/AuthArgumentResolver.java
@@ -43,6 +43,10 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            Auth auth = parameter.getParameterAnnotation(Auth.class);
+            if (auth != null && !auth.required()) {
+                return null;
+            }
             throw new IllegalArgumentException("Authorization 헤더가 없거나 Bearer 형식이 아닙니다.");
         }
 

--- a/src/main/java/kr/solta/adapter/webapi/response/RecentSolvedResponse.java
+++ b/src/main/java/kr/solta/adapter/webapi/response/RecentSolvedResponse.java
@@ -25,14 +25,15 @@ public record RecentSolvedResponse(
     ) {
     }
 
-    public static RecentSolvedResponse from(final SolvedWithTags solvedWithTags) {
+    public static RecentSolvedResponse from(final SolvedWithTags solvedWithTags, final Long viewerMemberId) {
         Solved solved = solvedWithTags.solved();
+        boolean isOwner = viewerMemberId != null && viewerMemberId.equals(solved.getMember().getId());
 
         return new RecentSolvedResponse(
                 solved.getId(),
                 solved.getSolveType(),
                 solved.getSolveTimeSeconds(),
-                solved.getMemo(),
+                isOwner ? solved.getMemo() : null,
                 new ProblemDetail(
                         solved.getProblem().getId(),
                         solved.getProblem().getBojProblemId(),


### PR DESCRIPTION
## Summary

풀이 메모를 본인만 조회할 수 있도록 BE API를 수정합니다.
기존에는 비인증 요청에도 타인의 메모가 응답에 포함되어 프라이버시 문제가 있었습니다.

### 동작 방식
1. `GET /members/solveds/search`, `GET /members/solveds/retry/search` 두 엔드포인트가 선택적 인증을 지원합니다.
2. 인증 토큰이 있으면 요청자의 memberId를 식별하고, 프로필 주인과 일치할 때만 memo 필드를 반환합니다.
3. 비인증 요청이거나 타인의 프로필 조회 시 memo는 `null`로 반환됩니다.

## 주요 변경 사항

- **`Auth.java`**: `required` 속성 추가 (`default true`). `@Auth(required = false)`로 선택적 인증 지원
- **`AuthArgumentResolver.java`**: `required = false`일 때 토큰 없으면 `null` 반환 (기존: 예외 발생)
- **`RecentSolvedResponse.java`**: `from(SolvedWithTags, Long viewerMemberId)` — viewerMemberId가 풀이 소유자와 일치할 때만 memo 포함
- **`SolvedController.java`**: `findSolvedWithAverages`, `findProblemsToRetry`에 `@Auth(required = false)` 추가

## Test plan
- [x] 비로그인 상태로 프로필 조회 시 memo `null` 확인
- [x] 본인 프로필 조회 시 memo 정상 반환 확인
- [x] 타인 프로필 조회 시 memo `null` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)