### PR TITLE
fix: 프로필 총 풀이 시간 계산을 SELF+SOLUTION 모두 합산으로 수정

### DIFF
--- a/src/main/java/kr/solta/application/required/SolvedRepository.java
+++ b/src/main/java/kr/solta/application/required/SolvedRepository.java
@@ -94,7 +94,7 @@ public interface SolvedRepository extends JpaRepository<Solved, Long> {
     List<TierAverage> findTierAverageByMemberAndTag(Member member, String tagKey);
 
     @Query("""
-                select new kr.solta.application.required.dto.AllSolvedAverage(count(s.id), coalesce(sum(case when s.solveType = kr.solta.domain.SolveType.SELF then s.solveTimeSeconds else 0 end), 0), avg(case when s.solveType = kr.solta.domain.SolveType.SELF then s.solveTimeSeconds else null end))
+                select new kr.solta.application.required.dto.AllSolvedAverage(count(s.id), coalesce(sum(s.solveTimeSeconds), 0), avg(case when s.solveType = kr.solta.domain.SolveType.SELF then s.solveTimeSeconds else null end))
                 from Solved s
                 where s.member = :member
             """)


### PR DESCRIPTION
## Summary
- 프로필 상단 총 풀이 시간이 SELF 타입만 합산되던 문제를 수정

## 왜 필요한가
- 기존 `findAllSolvedAverage` 쿼리에서 `totalSolvedTime`이 SELF 타입 풀이 시간만 합산하고 있었음
- 이번 주 요약의 총 풀이 시간(`SUM(solveTimeSeconds)`)과 계산 기준이 달라 불일치 발생

## 동작 방식
- `totalSolvedTime`: `SUM(CASE WHEN SELF ...)` → `SUM(solveTimeSeconds)` 로 변경하여 SELF+SOLUTION 모두 합산
- `totalSolvedAverageTime`: 기존과 동일하게 SELF 기준 `AVG(CASE WHEN SELF ...)` 유지

## 주요 변경 사항
- `SolvedRepository.java` - `findAllSolvedAverage` 쿼리의 totalSolvedTime 계산 수정

## Test plan
- [x] 프로필 상단 총 풀이 시간이 SOLUTION 풀이 시간도 포함하여 표시되는지 확인
- [x] 평균 시간은 여전히 SELF 기준으로 표시되는지 확인