### PR TITLE
refactor: TierGroup에 label/color 정의 및 BadgeSummaryStats 개선

### DIFF
--- a/src/main/java/kr/solta/application/BadgeService.java
+++ b/src/main/java/kr/solta/application/BadgeService.java
@@ -1,5 +1,7 @@
 package kr.solta.application;
 
+import static kr.solta.domain.TierGroup.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,33 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class BadgeService implements BadgeReader {
-
-    private static final List<TierGroup> BADGE_TIER_GROUPS = List.of(
-            TierGroup.BRONZE,
-            TierGroup.SILVER,
-            TierGroup.GOLD,
-            TierGroup.PLATINUM,
-            TierGroup.DIAMOND,
-            TierGroup.RUBY
-    );
-
-    private static final Map<TierGroup, String> TIER_LABELS = Map.of(
-            TierGroup.BRONZE, "B",
-            TierGroup.SILVER, "S",
-            TierGroup.GOLD, "G",
-            TierGroup.PLATINUM, "P",
-            TierGroup.DIAMOND, "D",
-            TierGroup.RUBY, "R"
-    );
-
-    private static final Map<TierGroup, String> TIER_COLORS = Map.of(
-            TierGroup.BRONZE, "hsl(30,70%,45%)",
-            TierGroup.SILVER, "hsl(210,15%,60%)",
-            TierGroup.GOLD, "hsl(45,100%,50%)",
-            TierGroup.PLATINUM, "hsl(175,60%,55%)",
-            TierGroup.DIAMOND, "hsl(200,100%,65%)",
-            TierGroup.RUBY, "hsl(350,85%,55%)"
-    );
 
     private final MemberRepository memberRepository;
     private final SolvedRepository solvedRepository;
@@ -79,12 +54,8 @@ public class BadgeService implements BadgeReader {
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다. username: " + username));
 
         BadgeSummaryStats summary = solvedRepository.findBadgeSummaryStats(member.getId());
-        Integer selfSolveRateRaw = solvedRepository.findSelfSolveRate(member.getId());
-        int selfSolveRate = selfSolveRateRaw != null ? selfSolveRateRaw : 0;
 
-        List<Tier> allBadgeTiers = BADGE_TIER_GROUPS.stream()
-                .flatMap(tg -> tg.getTiers().stream())
-                .toList();
+        List<Tier> allBadgeTiers = getRatedTiers();
         List<TierGroupStat> tierGroupStats = solvedRepository.findBadgeTierGroupStats(member.getId(), allBadgeTiers);
 
         Map<TierGroup, Double> avgSecondsByGroup = mapToTierGroupAvg(tierGroupStats);
@@ -94,14 +65,14 @@ public class BadgeService implements BadgeReader {
 
         List<TierDataItem> tierData = buildTierDataItems(avgSecondsByGroup);
 
-        return new BadgeStatsResponse(username, totalMinutes, avgMinutes, selfSolveRate, tierData);
+        return new BadgeStatsResponse(username, totalMinutes, avgMinutes, summary.selfSolveRate(), tierData);
     }
 
     private Map<TierGroup, Double> mapToTierGroupAvg(List<TierGroupStat> stats) {
         Map<Tier, TierGroupStat> statByTier = stats.stream()
                 .collect(Collectors.toMap(TierGroupStat::tier, s -> s));
 
-        return BADGE_TIER_GROUPS.stream()
+        return getRatedTierGroups().stream()
                 .collect(Collectors.toMap(
                         tg -> tg,
                         tg -> {
@@ -123,14 +94,10 @@ public class BadgeService implements BadgeReader {
 
     private List<TierDataItem> buildTierDataItems(Map<TierGroup, Double> avgSecondsByGroup) {
         List<TierDataItem> result = new ArrayList<>();
-        for (TierGroup tg : BADGE_TIER_GROUPS) {
+        for (TierGroup tg : getRatedTierGroups()) {
             double avgSeconds = avgSecondsByGroup.getOrDefault(tg, 0.0);
             int avgMinutes = (int) Math.round(avgSeconds / 60.0);
-            result.add(new TierDataItem(
-                    TIER_LABELS.get(tg),
-                    avgMinutes,
-                    TIER_COLORS.get(tg)
-            ));
+            result.add(new TierDataItem(tg.getLabel(), avgMinutes, tg.getColor()));
         }
         return result;
     }

--- a/src/main/java/kr/solta/application/required/SolvedRepository.java
+++ b/src/main/java/kr/solta/application/required/SolvedRepository.java
@@ -255,26 +255,13 @@ public interface SolvedRepository extends JpaRepository<Solved, Long> {
     @Query("""
                 SELECT new kr.solta.application.required.dto.BadgeSummaryStats(
                     coalesce(sum(s.solveTimeSeconds), 0),
-                    coalesce(avg(s.solveTimeSeconds), 0.0),
-                    count(s.id)
+                    coalesce(avg(case when s.solveType = kr.solta.domain.SolveType.SELF then s.solveTimeSeconds else null end), 0.0),
+                    CAST(ROUND(100.0 * AVG(CASE WHEN s.solveType = kr.solta.domain.SolveType.SELF THEN 1.0 ELSE 0.0 END)) AS integer)
                 )
                 FROM Solved s
                 WHERE s.member.id = :memberId
-                AND s.solveType = kr.solta.domain.SolveType.SELF
             """)
     BadgeSummaryStats findBadgeSummaryStats(Long memberId);
-
-    @Query("""
-                SELECT CAST(
-                    ROUND(
-                        100.0 * SUM(CASE WHEN s.solveType = kr.solta.domain.SolveType.SELF THEN 1 ELSE 0 END)
-                        / NULLIF(COUNT(s.id), 0)
-                    ) AS integer
-                )
-                FROM Solved s
-                WHERE s.member.id = :memberId
-            """)
-    Integer findSelfSolveRate(Long memberId);
 
     @Query("""
                 SELECT new kr.solta.application.required.dto.TierGroupStat(

--- a/src/main/java/kr/solta/application/required/dto/BadgeSummaryStats.java
+++ b/src/main/java/kr/solta/application/required/dto/BadgeSummaryStats.java
@@ -1,8 +1,12 @@
 package kr.solta.application.required.dto;
 
+
 public record BadgeSummaryStats(
         long totalSeconds,
         double avgSeconds,
-        long solveCount
+        Integer selfSolveRateRaw
 ) {
+    public int selfSolveRate() {
+        return selfSolveRateRaw != null ? selfSolveRateRaw : 0;
+    }
 }

--- a/src/main/java/kr/solta/domain/TierGroup.java
+++ b/src/main/java/kr/solta/domain/TierGroup.java
@@ -31,28 +31,44 @@ import static kr.solta.domain.Tier.S3;
 import static kr.solta.domain.Tier.S4;
 import static kr.solta.domain.Tier.S5;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public enum TierGroup {
-    NONE(List.of()),
-    UNRATED(List.of()),
-    BRONZE(List.of(B5, B4, B3, B2, B1)),
-    SILVER(List.of(S5, S4, S3, S2, S1)),
-    GOLD(List.of(G5, G4, G3, G2, G1)),
-    PLATINUM(List.of(P5, P4, P3, P2, P1)),
-    DIAMOND(List.of(D5, D4, D3, D2, D1)),
-    RUBY(List.of(R5, R4, R3, R2, R1)),
+    NONE(List.of(), false, null, null),
+    UNRATED(List.of(), false, null, null),
+    BRONZE(List.of(B5, B4, B3, B2, B1), true, "B", "hsl(30,70%,45%)"),
+    SILVER(List.of(S5, S4, S3, S2, S1), true, "S", "hsl(210,15%,60%)"),
+    GOLD(List.of(G5, G4, G3, G2, G1), true, "G", "hsl(45,100%,50%)"),
+    PLATINUM(List.of(P5, P4, P3, P2, P1), true, "P", "hsl(175,60%,55%)"),
+    DIAMOND(List.of(D5, D4, D3, D2, D1), true, "D", "hsl(200,100%,65%)"),
+    RUBY(List.of(R5, R4, R3, R2, R1), true, "R", "hsl(350,85%,55%)"),
     ;
 
     private final List<Tier> tiers;
+    private final boolean isRated;
+    private final String label;
+    private final String color;
 
-    TierGroup(final List<Tier> tiers) {
+    TierGroup(final List<Tier> tiers, final boolean isRated, final String label, final String color) {
         this.tiers = tiers;
+        this.isRated = isRated;
+        this.label = label;
+        this.color = color;
     }
 
-    public boolean isNone() {
-        return this == NONE;
+    public static List<Tier> getRatedTiers() {
+        return getRatedTierGroups().stream()
+                .flatMap(tg -> tg.getTiers().stream())
+                .toList();
+
+    }
+
+    public static List<TierGroup> getRatedTierGroups() {
+        return Arrays.stream(TierGroup.values())
+                .filter(TierGroup::isRated)
+                .toList();
     }
 }


### PR DESCRIPTION
## Summary
- `TierGroup` enum에 `label`, `color` 필드 추가 및 `getRatedTierGroups()` 정적 메서드 추가
- `BadgeService`의 `TIER_LABELS`, `TIER_COLORS` 정적 Map 제거
- `BadgeSummaryStats`에 `selfSolveRate` 통합 (`findSelfSolveRate` 쿼리 별도 제거)

## 왜 필요한가
티어 그룹의 라벨/컬러가 서비스 레이어에 흩어져 있어 새 티어 추가 시 여러 곳을 수정해야 하는 문제를 해결.

## 동작 방식
1. `TierGroup` enum이 `label`, `color`, `isRated` 속성을 직접 소유
2. `BadgeService`는 `tg.getLabel()`, `tg.getColor()`로 직접 참조
3. `selfSolveRate` 계산을 `findBadgeSummaryStats` 쿼리에 통합하여 DB 왕복 1회 감소
4. `BadgeSummaryStats`에 null-safe `selfSolveRate()` 접근자 추가

## 주요 변경 사항
- `domain/TierGroup.java` — `label`, `color`, `isRated` 필드 추가, `getRatedTierGroups()` 추가
- `application/BadgeService.java` — `TIER_LABELS`, `TIER_COLORS` Map 제거
- `application/required/SolvedRepository.java` — `findSelfSolveRate` 쿼리 제거, `findBadgeSummaryStats`에 통합
- `application/required/dto/BadgeSummaryStats.java` — `selfSolveRateRaw` 필드 및 `selfSolveRate()` 접근자 추가

## Test plan
- [x] 배지 SVG 생성 API 호출 확인
- [x] 배지 통계 API 응답에 selfSolveRate 정상 반환 확인