### PR TITLE
refactor: 레벨 칭호 영문으로 변경 

### DIFF
--- a/src/main/java/kr/solta/domain/LevelRange.java
+++ b/src/main/java/kr/solta/domain/LevelRange.java
@@ -1,12 +1,13 @@
 package kr.solta.domain;
 
 public enum LevelRange {
-    LV_1_10  (1,  10,  0,         150,   "코딩 새싹"),
-    LV_11_30 (11, 30,  1_500,     375,   "알고리즘 탐험가"),
-    LV_31_60 (31, 60,  9_000,     1_200, "문제 해결사"),
-    LV_61_90 (61, 90,  45_000,    3_500, "알고리즘 장인"),
-    LV_91_95 (91, 95,  150_000,   8_000, "전설"),
-    LV_96_100(96, 100, 190_000,  20_000, "전설");
+    LV_1_10  (1,   10,  0,        150,   "Newbie"),
+    LV_11_30 (11,  30,  1_500,    375,   "Pupil"),
+    LV_31_60 (31,  60,  9_000,    1_200, "Specialist"),
+    LV_61_90 (61,  90,  45_000,   3_500, "Expert"),
+    LV_91_95 (91,  95,  150_000,  8_000, "Master"),
+    LV_96_99 (96,  99,  190_000, 20_000, "Master"),
+    LV_100   (100, 100, 270_000,      0, "Legendary");
 
     private final int startLevel;
     private final int endLevel;
@@ -36,7 +37,7 @@ public enum LevelRange {
         for (LevelRange range : values()) {
             if (level >= range.startLevel && level <= range.endLevel) return range;
         }
-        return LV_96_100;  // level > 100 시에도 최상위 구간 반환
+        return LV_100;  // level > 100 시에도 최상위 구간 반환
     }
 
     // ---- 계산 ----

--- a/src/test/java/kr/solta/application/provided/XpReaderTest.java
+++ b/src/test/java/kr/solta/application/provided/XpReaderTest.java
@@ -44,7 +44,7 @@ class XpReaderTest extends IntegrationTest {
         //then
         assertThat(response.totalXp()).isEqualTo(81);
         assertThat(response.level()).isEqualTo(1);
-        assertThat(response.title()).isEqualTo("코딩 새싹");
+        assertThat(response.title()).isEqualTo("Newbie");
         assertThat(response.currentLevelXp()).isEqualTo(81);
         assertThat(response.nextLevelRequiredXp()).isEqualTo(150);
         assertThat(response.progressPercent()).isEqualTo(54); // 81 * 100 / 150 = 54

--- a/src/test/java/kr/solta/domain/LevelRangeTest.java
+++ b/src/test/java/kr/solta/domain/LevelRangeTest.java
@@ -83,13 +83,13 @@ class LevelRangeTest {
 
     @ParameterizedTest
     @CsvSource({
-            "1,   코딩 새싹",
-            "10,  코딩 새싹",
-            "11,  알고리즘 탐험가",
-            "31,  문제 해결사",
-            "61,  알고리즘 장인",
-            "91,  전설",
-            "100, 전설"
+            "1,   Newbie",
+            "10,  Newbie",
+            "11,  Pupil",
+            "31,  Specialist",
+            "61,  Expert",
+            "91,  Master",
+            "100, Legendary"
     })
     void 레벨별_타이틀이_올바르다(final int level, final String expectedTitle) {
         assertThat(LevelRange.getTitle(level)).isEqualTo(expectedTitle);


### PR DESCRIPTION
## Summary
- 레벨 칭호를 Codeforces 스타일 영문으로 변경

## 왜 필요한가
- 기존 칭호(코딩 새싹, 알고리즘 탐험가 등)가 어색하다는 피드백
- PS 커뮤니티에서 익숙한 영문 칭호로 교체

## 주요 변경 사항
- `LevelRange.java`: 칭호 변경 + `LV_96_100` → `LV_96_99` + `LV_100` 분리
  - Newbie (Lv 1~10)
  - Pupil (Lv 11~30)
  - Specialist (Lv 31~60)
  - Expert (Lv 61~90)
  - Master (Lv 91~99)
  - Legendary (Lv 100)
- `LevelRangeTest.java`, `XpReaderTest.java`: 기대값 수정

## Test plan
- [x] `./gradlew test --tests "*LevelRangeTest"` 통과
- [x] `./gradlew test --tests "*XpReaderTest"` 통과